### PR TITLE
Add fund-distribution list & added workflow to run funding-tool

### DIFF
--- a/.github/workflows/generate-funding-list.yml
+++ b/.github/workflows/generate-funding-list.yml
@@ -1,0 +1,47 @@
+
+name: Generate funding list
+
+on:
+  workflow_dispatch:
+
+jobs:
+  generate_list:
+    name: Generate funding list
+    runs-on: ubuntu-latest
+    env:
+      FUNDINGTOOL_PRIVKEY: '${{ secrets.FUNDINGTOOL_PRIVKEY }}'
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run funding-tool
+      run: |
+        cd fund-distribution
+
+        tmp_dir=$(mktemp -d -t ft-XXXXXXXXXX)
+        fundingtool_release=`curl --silent "https://api.github.com/repos/pk910/testnet-funding-tool/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | head -n 1`
+        echo "Download testnet-funding-tool v${fundingtool_release}"
+        wget -O $tmp_dir/funding-tool https://github.com/pk910/testnet-funding-tool/releases/download/$fundingtool_release/funding-tool-amd64
+        chmod +x $tmp_dir/funding-tool
+
+        echo "Run funding-tool"
+        $tmp_dir/funding-tool -f ./funding-list.txt -m 20 --use-distributor --distributor-batch-size 20 --gaslimit 1000000 --maxfeepergas 200 --maxpriofee 5 -p env --random-privkey -o ./transactions.txt --chainid 11166111 --summary ./summary.txt
+
+    #- uses: stefanzweifel/git-auto-commit-action@v4
+    #  with:
+    #    commit_message: Commit generated funding & transactio list
+    #    branch: master
+    #    push_options: '--force'
+    #    skip_checkout: true
+
+    - name: Upload transactions.txt artifact
+      uses: actions/upload-artifact@v3
+      with:
+        path: ./fund-distribution/transactions.txt
+        name: transactions.txt
+    - name: Upload summary.txt artifact
+      uses: actions/upload-artifact@v3
+      with:
+        path: ./fund-distribution/summary.txt
+        name: summary.txt
+
+

--- a/.github/workflows/generate-funding-list.yml
+++ b/.github/workflows/generate-funding-list.yml
@@ -26,6 +26,10 @@ jobs:
         echo "Run funding-tool"
         $tmp_dir/funding-tool -f ./funding-list.txt -m 20 --use-distributor --distributor-batch-size 20 --gaslimit 1000000 --maxfeepergas 200 --maxpriofee 5 -p env --random-privkey -o ./transactions.txt --chainid 11166111 --summary ./summary.txt
 
+        echo ""
+        echo "Distribution Summary:"
+        cat ./summary.txt
+
     #- uses: stefanzweifel/git-auto-commit-action@v4
     #  with:
     #    commit_message: Commit generated funding & transactio list


### PR DESCRIPTION
Heya,

I've implemented a workflow that runs the funding-tool and outputs a list of signed transactions.
The workflow is currently triggered manually only, but can simply be extended by a scheduled date.

When the workflow runs, it takes the `funding-list.txt` and generates 2 files (uploaded as artifacts):
1. A `summary.txt`, which contains the wallet address, total amount and some more details
2. A `transactions.txt`, which contains a list of signed transactions, one per line.

The transactions from the `transactions.txt` can be submitted & executed by anyone who wants once the network is live. 
There is no more central point of trust that needs to do them.

The funding-tool uses a predefined private key from a github secret, or (what I'd recommend) a random privkey that is destroyed afterwards.
The (random) wallet address just needs to be pre-funded with the total distribution amount + some extra for tx fees.

I'd suggest that this action is triggered once when we've agreed on the distribution details (#9), but a few weeks before the genesis state is freezed.
The result should be added to this repository, so anyone can verify these transactions do actually work.
If there is nothing to complain about, the wallet address can be added to the genesis file with the total amount, and it's ready to go :)
