### PR TITLE
Fixing field in geth config

### DIFF
--- a/custom_config_data/genesis.json
+++ b/custom_config_data/genesis.json
@@ -11,7 +11,7 @@
     "istanbulBlock": 0,
     "berlinBlock": 0,
     "londonBlock": 0,
-    "mergeForkBlock": 0,
+    "mergeNetsplitBlock": 0,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
     "shanghaiTime": 1694884704,


### PR DESCRIPTION
The field `mergeForkBlock` was incorrectly used, it should instead be `mergeNetsplitBlock`