### PR TITLE
Fix comments on genesis time in config.yaml

### DIFF
--- a/custom_config_data/config.yaml
+++ b/custom_config_data/config.yaml
@@ -6,8 +6,7 @@ CONFIG_NAME: holesky
 # ---------------------------------------------------------------
 # `2**14` (= 16,384)
 MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 16384
-# Sep-15-2023 14:55:00 +UTC
-# This is an invalid valid and should be updated when you create the genesis
+# Sep-15-2023 13:55:00 +UTC
 MIN_GENESIS_TIME: 1694786100
 GENESIS_FORK_VERSION: 0x00017000
 # Genesis delay 5 mins


### PR DESCRIPTION
Clarify that genesis is actually 13:55:00 UTC, _not_ 14:55:00 UTC. It looks like UTC was mixed up with London summer time (UTC+1), or subject to some other off-by-one error.

I also removed the comment about the genesis time being invalid (it's not).