### PR TITLE
remove parsed beacon state file

### DIFF
--- a/custom_config_data/parsedBeaconState.json
+++ b/custom_config_data/parsedBeaconState.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:375aea2fb27dc5dc35728d9e5c322c77b993cb1cfe7747dd690785f797985c5f
-size 756689709


### PR DESCRIPTION
The parsedBeaconState file is ~720mb and serving it is affecting our git lfs bill by a lot. This PR would remove it, if someone wants the file they can always re-generate it locally with the command: `zcli pretty bellatrix  BeaconState genesis.ssz > parsedBeaconState.json`