### PR TITLE
Add Chainlens explorer for Holesky

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Meet `--holesky`, the first long-standing, merged-from-genesis, public Ethereum 
   * [holesky.beaconcha.in](https://holesky.beaconcha.in/)
   * [dora-holesky.pk910.de](https://dora-holesky.pk910.de/)
   * [eth-holesky.blockscout.com](https://eth-holesky.blockscout.com/)
+  * [holesky.chainlens.com](https://holesky.chainlens.com/)
 * Ethstats: [ethstats.holesky.ethpandaops.io](https://ethstats.holesky.ethpandaops.io)
 * Faucets:
   * [holesky-faucet.pk910.de](https://holesky-faucet.pk910.de/)


### PR DESCRIPTION
This PR simply adds the Chainlens explorer for Holesky test network.