### PR TITLE
add pragueTime and system contract addresses

### DIFF
--- a/metadata/besu.json
+++ b/metadata/besu.json
@@ -15,7 +15,23 @@
     "terminalTotalDifficulty": 0,
     "shanghaiTime": 1696000704,
     "cancunTime": 1707305664,
+    "pragueTime": 1740434112,
+    "blobSchedule": {
+      "cancun": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      },
+      "prague": {
+        "target": 6,
+        "max": 9,
+        "baseFeeUpdateFraction": 5007716
+      }
+    },
     "ethash": {},
+    "depositContractAddress": "0x4242424242424242424242424242424242424242",
+    "withdrawalRequestContractAddress": "0x00000961ef480eb55e80d19ad83579a64c007002",
+    "consolidationRequestContractAddress": "0x0000bbddc7ce488642fb579f8b00f3a590007251",
     "discovery": {
       "bootnodes": [
         "enode://ac906289e4b7f12df423d654c5a962b6ebe5b3a74cc9e06292a85221f9a64a6f1cfdd6b714ed6dacef51578f92b34c60ee91e9ede9c7f8fadc4d347326d95e2b@146.190.13.128:30303",


### PR DESCRIPTION
besu has [changed](https://github.com/hyperledger/besu/pull/8567) to fail early if system contract addresses are not present.